### PR TITLE
Remove Support for Packaging the Library

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,15 +28,8 @@ jobs:
       - name: Check Lint
         run: yarn lint
 
+      - name: Build Library
+        run: yarn build
+
       - name: Test Library
         run: yarn test
-
-      - name: Package Library
-        run: yarn pack
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          path: package.tgz
-          if-no-files-found: error
-          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 
 dist/
 node_modules/
-
-package.tgz

--- a/package.json
+++ b/package.json
@@ -2,17 +2,11 @@
   "name": "my_bot",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "bin": "dist/bin.js",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "tsc",
     "format": "prettier --write --cache .",
     "lint": "eslint",
-    "prepack": "tsc",
     "test": "jest"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  "include": ["src"],
-  "exclude": ["**/*.test.*"],
+  "include": ["src/bin.ts"],
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
-    "declaration": true,
     "outDir": "dist",
     "esModuleInterop": true,
     "target": "es2022",


### PR DESCRIPTION
This pull request resolves #3 by removing support for packaging the library, including deleting entries in `package.json`, adjusting the GitHub Action workflow, and modifying the TypeScript configuration.