### PR TITLE
Specify Base User Directory in Client Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "my_bot",
   "private": true,
   "type": "module",
-  "main": "src/bin.ts",
   "bin": "dist/bin.js",
   "scripts": {
     "build": "tsc",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,6 +5,7 @@ import "@sapphire/plugin-logger/register";
 import { GatewayIntentBits } from "discord.js";
 
 const client = new SapphireClient({
+  baseUserDirectory: import.meta.dirname,
   intents: [GatewayIntentBits.Guilds],
   loadMessageCommandListeners: true,
 });


### PR DESCRIPTION
This pull request resolves #17 by specifying the base user directory in client options using the `baseUserDirectory` option, effectively allowing the `main` entry in the `package.json` file to be removed.