### PR TITLE
Remove Build Support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,5 +28,5 @@ jobs:
       - name: Check Lint
         run: yarn lint
 
-      - name: Build Library
-        run: yarn build
+      - name: Check Types
+        run: yarn check-types

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 !.git*
 !.nvmrc
 
-dist/
 node_modules/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,6 @@ export default [
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
   {
-    ignores: [".*", "dist"],
+    ignores: [".*"],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "my_bot",
   "private": true,
   "type": "module",
-  "bin": "dist/bin.js",
   "scripts": {
-    "build": "tsc",
+    "check-types": "tsc",
     "dev": "tsx src/bin.ts",
     "format": "prettier --write --cache .",
     "lint": "eslint"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "check-types": "tsc",
-    "dev": "tsx src/bin.ts",
+    "start": "tsx src/bin.ts",
     "format": "prettier --write --cache .",
     "lint": "eslint"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-  "include": ["src/bin.ts"],
+  "include": ["src"],
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
-    "outDir": "dist",
+    "noEmit": true,
     "esModuleInterop": true,
     "target": "es2022",
     "skipLibCheck": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,8 +2100,6 @@ __metadata:
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.6.3"
     typescript-eslint: "npm:^8.13.0"
-  bin:
-    my_bot: dist/bin.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This pull request resolves #19 by removing support for building the TypeScript source files to JavaScript. It also modifies the `build` script to a `check-types` script and renames the `dev` script to `start`.