### PR TITLE
Merge Check Scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,13 +20,5 @@ jobs:
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
 
-      - name: Check Formatting
-        run: |
-          yarn format
-          git diff --exit-code HEAD
-
-      - name: Check Lint
-        run: yarn lint
-
-      - name: Check Types
-        run: yarn check-types
+      - name: Check Formatting, Linting, and Types
+        run: yarn check

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  build-library:
-    name: Build Library
+  check-project:
+    name: Check Project
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project

--- a/package.json
+++ b/package.json
@@ -3,10 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check-types": "tsc",
-    "start": "tsx src/bin.ts",
-    "format": "prettier --write --cache .",
-    "lint": "eslint"
+    "check": "prettier --check . && eslint && tsc",
+    "start": "tsx src/bin.ts"
   },
   "dependencies": {
     "@sapphire/framework": "^5.3.1",


### PR DESCRIPTION
This pull request resolves #22 by merging the `check-types`, `format`, and `lint` scripts into a single `check` script. It also renames the `build-library` job in the `build` workflow to `check-project` since it only verifies the source code within the sample project.