### PR TITLE
Catch Error During Login

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,15 @@
-import { SapphireClient } from "@sapphire/framework";
+import { container, SapphireClient } from "@sapphire/framework";
 import "@sapphire/plugin-logger/register";
 import { GatewayIntentBits } from "discord.js";
 
-const client = new SapphireClient({
-  baseUserDirectory: import.meta.dirname,
-  intents: [GatewayIntentBits.Guilds],
-  loadMessageCommandListeners: true,
-});
+try {
+  const client = new SapphireClient({
+    baseUserDirectory: import.meta.dirname,
+    intents: [GatewayIntentBits.Guilds],
+    loadMessageCommandListeners: true,
+  });
 
-client.login();
+  await client.login();
+} catch (err) {
+  container.logger.error("Failed to login:", err);
+}


### PR DESCRIPTION
This pull request resolves #26 by modifying the sample main entry point file to catch errors during the Bot client login, providing a standardized context for the reason of login failure.