### PR TITLE
Add Docker Support in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore
+    labels: [chore]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This pull request resolves #34 by adding a `docker` entry in the `dependabot.yaml` file, enabling Dependabot to check for Docker image version updates.