### PR TITLE
Add Usage Guide in Readme File

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,85 @@ This template provides a basic Discord bot project containing a sample bot appli
 - Uses [Yarn](https://yarnpkg.com/) as the package manager with [Plug'n'Play](https://yarnpkg.com/features/pnp) support.
 - Supports formatting with [Prettier](https://prettier.io/) and linting with [ESLint](https://eslint.org/).
 - Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions).
+
+## Usage
+
+This guide explains how to use this template to start a new Discord bot project, from creation to deployment.
+
+### Create a New Project
+
+Follow [this link](https://github.com/new?template_name=discord-bot-starter&template_owner=threeal) to create a new project based on this template. For more information about creating a repository from a template on GitHub, refer to [this documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
+
+Alternatively, you can clone this repository locally to begin using this template.
+
+### Choose a License
+
+By default, this template is [unlicensed](https://unlicense.org/). Before modifying this template, replace the [`LICENSE`](./LICENSE) file with the license to be used by the new project. For more information about licensing a repository, refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
+
+Alternatively, you can remove the `LICENSE` file or leave it as-is to keep the new project unlicensed.
+
+### Update the Readme File
+
+Update the content of this [`README.md`](./README.md) file with a description of the new project. For more information on adding READMEs to a project, refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes).
+
+### Set Up the Tools
+
+It is recommended to use [nvm](https://github.com/nvm-sh/nvm) to manage the Node.js version in the project. By default, this template uses the Node.js version specified in the [`.nvmrc`](./.nvmrc) file. Use the following command to install and use the correct Node.js version with nvm:
+
+```sh
+nvm install
+```
+
+This template uses [Yarn](https://yarnpkg.com/) with [Plug'n'Play](https://yarnpkg.com/features/pnp) support as the package manager. If Yarn is not yet enabled, run the following command:
+
+```sh
+corepack enable yarn
+```
+
+Then, install the project dependencies with:
+
+```sh
+yarn install
+```
+
+For more information on Yarn, such as adding dependencies or running tools, refer to [this documentation](https://yarnpkg.com/getting-started).
+
+### Set Up the Bot Application
+
+Before developing the bot application, ensure that you have set up a bot application and obtained a token to be used to access the bot. If not, refer to [this documentation](https://discord.com/developers/docs/quick-start/getting-started) for setting up a new bot application and getting the access token.
+
+After obtaining the access token, export it as a `DISCORD_TOKEN` variable either in your shell environment or in an `.env.yarn` file.
+
+### Develop the Bot Application
+
+Develop the bot application by modifying the files under the [`src`](./src) directory according to the project requirements. For more detailed guidance on developing the bot application, refer to the [Sapphire documentation](https://sapphirejs.dev/docs/General/Welcome) and the [TypeScript documentation](https://www.typescriptlang.org/docs/).
+
+Every time the code is written, check if it adheres to the standard conventions with the following command:
+
+```sh
+yarn check
+```
+
+After you're done, run the bot application using the following command:
+
+```sh
+yarn start
+```
+
+### Deploy the Bot Application
+
+The bot application can simply be deployed by running the `yarn start` command on a specific machine. Alternatively, the bot application can also be deployed as a [Docker](https://www.docker.com/) container, allowing it to run as a service while keeping the application contained in an isolated environment.
+
+To do this, first, build the bot application into a Docker image using the following command:
+
+```sh
+docker build -t discord-bot .
+```
+
+Then run the Docker image as a service using the following command:
+
+```sh
+docker run -d --restart unless-stopped discord-bot
+```
+
+Refer to [this documentation](https://docs.docker.com/guides/) for more information on using Docker for managing containerized applications.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "my_bot",
   "private": true,
   "type": "module",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,24 +1984,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"my_bot@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "my_bot@workspace:."
-  dependencies:
-    "@eslint/js": "npm:^9.14.0"
-    "@sapphire/framework": "npm:^5.3.1"
-    "@sapphire/plugin-logger": "npm:^4.0.2"
-    "@types/node": "npm:^22.9.0"
-    discord-api-types: "npm:^0.37.104"
-    discord.js: "npm:^14.16.3"
-    eslint: "npm:^9.14.0"
-    prettier: "npm:^3.3.3"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.6.3"
-    typescript-eslint: "npm:^8.14.0"
-  languageName: unknown
-  linkType: soft
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -2209,6 +2191,24 @@ __metadata:
   checksum: 10c0/c19ef26e4e188f408922c46f7ff480d38e8dfc55d448310dfb518736b23ed2c4f547fb64a6ed5bdba92cd7e7ddc889d36ff78f794816d5e71498d645ef476107
   languageName: node
   linkType: hard
+
+"root-workspace-0b6124@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "root-workspace-0b6124@workspace:."
+  dependencies:
+    "@eslint/js": "npm:^9.14.0"
+    "@sapphire/framework": "npm:^5.3.1"
+    "@sapphire/plugin-logger": "npm:^4.0.2"
+    "@types/node": "npm:^22.9.0"
+    discord-api-types: "npm:^0.37.104"
+    discord.js: "npm:^14.16.3"
+    eslint: "npm:^9.14.0"
+    prettier: "npm:^3.3.3"
+    tsx: "npm:^4.19.2"
+    typescript: "npm:^5.6.3"
+    typescript-eslint: "npm:^8.14.0"
+  languageName: unknown
+  linkType: soft
 
 "run-parallel@npm:^1.1.9":
   version: 1.2.0


### PR DESCRIPTION
This pull request resolves #36 by adding a new "Usage Guide" section in the `README.md` file. To simplify template usage, it also removes the sample project name in the `package.json` file.