### PR TITLE
Merge Jobs in Build Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  check-project:
-    name: Check Project
+  build-project:
+    name: Build Project
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Project
@@ -22,13 +22,6 @@ jobs:
 
       - name: Check Formatting, Linting, and Types
         run: yarn check
-
-  build-image:
-    name: Build Image
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout Project
-        uses: actions/checkout@v4.2.2
 
       - name: Build Image
         run: docker build .


### PR DESCRIPTION
This pull request resolves #38 by merging jobs in the `build` workflow to a single `build-project` job.