### PR TITLE
Fix Failed Login Exiting with Zero Status Code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,5 @@ try {
   await client.login();
 } catch (err) {
   container.logger.error("Failed to login:", err);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
This pull request resolves #44 by updating the sample main entrypoint script to exit with code `1` on a failed login.