### PR TITLE
Remove Dependabot Label Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,6 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]
 
   - package-ecosystem: github-actions
     directory: /
@@ -14,7 +13,6 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]
 
   - package-ecosystem: npm
     directory: /
@@ -22,5 +20,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]
     versioning-strategy: increase


### PR DESCRIPTION
This pull request resolves #614 by removing the `labels` entry from the `dependabot.yaml` configuration file.