### PR TITLE
Configure Dependabot Label to Empty

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: []
 
   - package-ecosystem: github-actions
     directory: /
@@ -13,6 +14,7 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: []
 
   - package-ecosystem: npm
     directory: /
@@ -20,4 +22,5 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: []
     versioning-strategy: increase


### PR DESCRIPTION
This pull request resolves #51 by configuring Dependabot labels in the `dependabot.yaml` file to an empty array, ensuring that Dependabot won't assign any labels to newly created pull requests.