### PR TITLE
Add Entrypoint Command for the Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN corepack enable yarn
 RUN yarn workspaces focus --production
 COPY . .
 
-CMD yarn start
+ENTRYPOINT ["yarn", "start"]


### PR DESCRIPTION
This pull request resolves #77 by adding an `ENTRYPOINT` instruction to the `Dockerfile`, replacing the `CMD` instruction.