### PR TITLE
Integrate Lefthook

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,8 +23,11 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Check Formatting, Linting, and Types
-        run: pnpm check
+      - name: Check Formatting
+        run: pnpm prettier --check .
+
+      - name: Check Lint
+        run: pnpm eslint
 
       - name: Build Image
         run: docker build .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,5 +29,8 @@ jobs:
       - name: Check Lint
         run: pnpm eslint
 
+      - name: Check Types
+        run: pnpm tsc --noEmit
+
       - name: Build Image
         run: docker build .

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This template provides a basic Discord bot project containing a sample bot appli
 - Minimal Discord bot project written in TypeScript with [ESM](https://nodejs.org/api/esm.html) support.
 - Uses Sapphire as the framework for creating the Discord bot application.
 - Supports building the Discord bot application as a Docker image.
-- Uses [pnpm](https://pnpm.io//) as the package manager.
+- Uses [pnpm](https://pnpm.io/) as the package manager.
 - Supports formatting with [Prettier](https://prettier.io/) and linting with [ESLint](https://eslint.org/).
+- Fixes formatting and linting during pre-commit hooks using [Lefthook](https://lefthook.dev/).
 - Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions).
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ After obtaining the access token, export it as a `DISCORD_TOKEN` variable in you
 
 Develop the bot application by modifying the files under the [`src`](./src) directory according to the project requirements. For more detailed guidance on developing the bot application, refer to the [Sapphire documentation](https://sapphirejs.dev/docs/General/Welcome) and the [TypeScript documentation](https://www.typescriptlang.org/docs/).
 
-Every time the code is written, check if it adheres to the standard conventions with the following command:
-
-```sh
-pnpm check
-```
-
 After you're done, run the bot application using the following command:
 
 ```sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,19 @@
+pre-commit:
+  piped: true
+  jobs:
+    - name: fix formatting
+      run: pnpm prettier --write --ignore-unknown {staged_files}
+
+    - name: fix lint
+      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+
+    - name: check types
+      run: pnpm tsc
+      glob:
+        - src/*.ts
+        - .nvmrc
+        - pnpm-lock.yaml
+        - tsconfig.json
+
+    - name: check diff
+      run: git diff --exit-code {staged_files}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "prettier --check . && eslint && tsc",
     "start": "tsx src/index.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
     "@eslint/js": "^9.22.0",
     "@types/node": "^22.13.10",
     "eslint": "^9.22.0",
+    "lefthook": "^1.11.3",
     "prettier": "^3.5.3",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "esbuild"
+      "esbuild",
+      "lefthook"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       eslint:
         specifier: ^9.22.0
         version: 9.22.0
+      lefthook:
+        specifier: ^1.11.3
+        version: 1.11.3
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -648,6 +651,60 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lefthook-darwin-arm64@1.11.3:
+    resolution: {integrity: sha512-IYzAOf8Qwqk7q+LoRyy7kSk9vzpUZ5wb/vLzEAH/F86Vay9AUaWe1f2pzeLwFg18qEc1QNklT69h9p/uLQMojA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.11.3:
+    resolution: {integrity: sha512-z/Wp7UMjE1Vyl+x9sjN3NvN6qKdwgHl+cDf98MKKDg/WyPE5XnzqLm9rLLJgImjyClfH7ptTfZxEyhTG3M3XvQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.11.3:
+    resolution: {integrity: sha512-QevwQ7lrv5wBCkk7LLTzT5KR3Bk/5nttSxT1UH2o0EsgirS/c2K5xSgQmV6m3CiZYuCe2Pja4BSIwN3zt17SMw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.11.3:
+    resolution: {integrity: sha512-PYbcyNgdJJ4J2pEO9Ss4oYo5yq4vmQGTKm3RTYbRx4viSWR65hvKCP0C4LnIqspMvmR05SJi2bqe7UBP2t60EA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.11.3:
+    resolution: {integrity: sha512-0pBMBAoafOAEg345eOPozsmRjWR0zCr6k+m5ZxwRBZbZx1bQFDqBakQ3TpFCphhcykmgFyaa1KeZJZUOrEsezA==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.11.3:
+    resolution: {integrity: sha512-eiezheZ/bisBCMB2Ur0mctug/RDFyu39B5wzoE8y4z0W1yw6jHGrWMJ4Y8+5qKZ7fmdZg+7YPuMHZ2eFxOnhQA==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.11.3:
+    resolution: {integrity: sha512-DRLTzXdtCj/TizpLcGSqXcnrqvgxeXgn/6nqzclIGqNdKCsNXDzpI0D3sP13Vwwmyoqv2etoTak2IHqZiXZDqg==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.11.3:
+    resolution: {integrity: sha512-l7om+ZjWpYrVZyDuElwnucZhEqa7YfwlRaKBenkBxEh2zMje8O6Zodeuma1KmyDbSFvnvEjARo/Ejiot4gLXEw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.11.3:
+    resolution: {integrity: sha512-X0iTrql2gfPAkU2dzRwuHWgW5RcqCPbzJtKQ41X6Y/F7iQacRknmuYUGyC81funSvzGAsvlusMVLUvaFjIKnbA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.11.3:
+    resolution: {integrity: sha512-F+ORMn6YJXoS0EXU5LtN1FgV4QX9rC9LucZEkRmK6sKmS7hcb9IHpyb7siRGytArYzJvXVjPbxPBNSBdN4egZQ==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.11.3:
+    resolution: {integrity: sha512-HJp37y62j3j8qzAOODWuUJl4ysLwsDvCTBV6odr3jIRHR/a5e+tI14VQGIBcpK9ysqC3pGWyW5Rp9Jv1YDubyw==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1457,6 +1514,49 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  lefthook-darwin-arm64@1.11.3:
+    optional: true
+
+  lefthook-darwin-x64@1.11.3:
+    optional: true
+
+  lefthook-freebsd-arm64@1.11.3:
+    optional: true
+
+  lefthook-freebsd-x64@1.11.3:
+    optional: true
+
+  lefthook-linux-arm64@1.11.3:
+    optional: true
+
+  lefthook-linux-x64@1.11.3:
+    optional: true
+
+  lefthook-openbsd-arm64@1.11.3:
+    optional: true
+
+  lefthook-openbsd-x64@1.11.3:
+    optional: true
+
+  lefthook-windows-arm64@1.11.3:
+    optional: true
+
+  lefthook-windows-x64@1.11.3:
+    optional: true
+
+  lefthook@1.11.3:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.11.3
+      lefthook-darwin-x64: 1.11.3
+      lefthook-freebsd-arm64: 1.11.3
+      lefthook-freebsd-x64: 1.11.3
+      lefthook-linux-arm64: 1.11.3
+      lefthook-linux-x64: 1.11.3
+      lefthook-openbsd-arm64: 1.11.3
+      lefthook-openbsd-x64: 1.11.3
+      lefthook-windows-arm64: 1.11.3
+      lefthook-windows-x64: 1.11.3
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
This pull request resolves #153 by integrating [Lefthook](https://lefthook.dev/) into this project, allowing pre-commit hooks to be installed and executed on staged files. In doing so, this change also removes the `check` script as it is no longer necessary. It also added a new `Check Types` step in the `build` workflow.