### PR TITLE
Extend TypeScript Configuration from Node.js Base Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@tsconfig/node23": "^23.0.1",
     "@types/node": "^22.13.10",
     "eslint": "^9.22.0",
     "lefthook": "^1.11.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@eslint/js':
         specifier: ^9.22.0
         version: 9.22.0
+      '@tsconfig/node23':
+        specifier: ^23.0.1
+        version: 23.0.1
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -355,6 +358,9 @@ packages:
   '@sapphire/utilities@3.18.2':
     resolution: {integrity: sha512-QGLdC9+pT74Zd7aaObqn0EUfq40c4dyTL65pFnkM6WO1QYN7Yg/s4CdH+CXmx0Zcu6wcfCWILSftXPMosJHP5A==}
     engines: {node: '>=v14.0.0'}
+
+  '@tsconfig/node23@23.0.1':
+    resolution: {integrity: sha512-oJ0Y42TmsBLuLAfEbPTS5JXSbJJEEU4bULROS6zsL54Gdlw5aOy27rpsquotMKGf2auP6rkbfYsjl43WdGrNcg==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1151,6 +1157,8 @@ snapshots:
   '@sapphire/timestamp@1.0.5': {}
 
   '@sapphire/utilities@3.18.2': {}
+
+  '@tsconfig/node23@23.0.1': {}
 
   '@types/estree@1.0.6': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,7 @@
 {
+  "extends": "@tsconfig/node23",
   "include": ["src"],
   "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
-    "strict": true,
-    "module": "node16",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "target": "es2022",
-    "skipLibCheck": true
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This pull request resolves #159 by extending `tsconfig.json` from [@tsconfig/node23](https://www.npmjs.com/package/@tsconfig/node23).