### PR TITLE
Use Debian Docker Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .*
 !.env*
+!.npmrc
 
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM node:23.10.0-alpine
+FROM debian:bookworm-slim
 
-ENV PNPM_HOME="$HOME/.local/share/pnpm"
+ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH="$PNPM_HOME:$PATH"
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+
+RUN apt-get update && apt-get install -y wget
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV=/root/.shrc SHELL="$(which sh)" sh -
 
 WORKDIR /app
 COPY . .
+
 RUN pnpm install --prod
 
 ENTRYPOINT ["pnpm", "start"]


### PR DESCRIPTION
This pull request resolves #161 by replacing the Node.js Docker image with a Debian-based Docker image. This change also updates the build steps in the `Dockerfile` accordingly.