### PR TITLE
Bump Node.js to Version 24.14.1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.14.0
+use-node-version=24.14.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.14.0-alpine
+FROM node:24.14.1-alpine
 
 ENV PNPM_HOME="$HOME/.local/share/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION
This pull request bumps the Node.js version specified in the `.npmrc` and `Dockerfile` files to version [24.14.1](https://github.com/nodejs/node/releases/tag/v24.14.1).