### PR TITLE
Lock pnpm to Version 10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:24.14.1-alpine
 
 ENV PNPM_HOME="$HOME/.local/share/pnpm"
+ENV PNPM_VERSION="10.33.4"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
 

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
     "prettier-plugin-organize-imports": "^4.3.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0"
-  }
+  },
+  "packageManager": "pnpm@10.33.4"
 }


### PR DESCRIPTION
This pull request resolves #470 by locking the pnpm version used in this project to version 10.33.4 in the GitHub Actions workflow, `Dockerfile`, and `package.json`.