### PR TITLE
Bump Node.js to Version 24.15.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.14.1
+use-node-version=24.15.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.14.1-alpine
+FROM node:24.15.0-alpine
 
 ENV PNPM_HOME="$HOME/.local/share/pnpm"
 ENV PNPM_VERSION="10.33.4"


### PR DESCRIPTION
This pull request updates the Node.js version specified in the `.npmrc` file to [24.15.0](https://github.com/nodejs/node/releases/tag/v24.15.0).